### PR TITLE
Add prompt for filename when generating reports

### DIFF
--- a/base_station/gui/src/components/GenerateReport.vue
+++ b/base_station/gui/src/components/GenerateReport.vue
@@ -55,7 +55,8 @@ export default {
         hiddenElement.target = '_blank';  
         
         //provide the name for the CSV file to be downloaded  
-        hiddenElement.download = 'Report'+ timeString+'.csv';  
+        let report_name = prompt("Enter filename:", timeString);  
+        hiddenElement.download = report_name+'.csv';  
         hiddenElement.click();  
     }  
     }

--- a/base_station/gui/src/components/GenerateTriadReport.vue
+++ b/base_station/gui/src/components/GenerateTriadReport.vue
@@ -46,8 +46,9 @@ export default {
         hiddenElement.href = 'data:text/csv;charset=utf-8,' + encodeURI(csv);  
         hiddenElement.target = '_blank';  
         
-        //provide the name for the CSV file to be downloaded  
-        hiddenElement.download = 'Report'+ timeString+'.csv';  
+        //provide the name for the CSV file to be downloaded
+        let report_name = prompt("Enter filename:", timeString);  
+        hiddenElement.download = report_name+'.csv';  
         hiddenElement.click();  
     }  
     }


### PR DESCRIPTION
Default filename is timestamp

![FilenamePrompt](https://user-images.githubusercontent.com/91024925/159175937-bf0428a8-dc4c-42b3-b3ec-f2fae36cfab9.png)

